### PR TITLE
Changes from background agent bc-95a48f9c-a031-4499-8611-58d68f887217

### DIFF
--- a/BUG_FIXES.md
+++ b/BUG_FIXES.md
@@ -1,0 +1,147 @@
+# Bug Fixes Summary
+
+This document outlines the 3 critical bugs found and fixed in the BillBuddy application.
+
+## Bug 1: PDF Parser Merchant-Amount Mismatch (Critical Logic Error)
+
+**Problem Description:**
+The main issue reported by the user was that when parsing PDFs, the merchant names and amounts didn't match correctly. This was caused by a fundamental flaw in the `parseSCStatement` function where the parsing logic extracted descriptions and amounts separately, then tried to match them by index position.
+
+**Root Cause:**
+- The original parser used separate regex patterns to extract merchant descriptions and transaction amounts
+- It then attempted to align them by array index, which fails when:
+  - PDF structure varies between statements
+  - There are different numbers of transactions vs descriptions
+  - The PDF layout doesn't follow the expected pattern
+
+**Fix Applied:**
+- Implemented a new parsing approach that looks for complete transaction blocks
+- Each transaction block is parsed as a unit, ensuring merchant and amount stay together
+- Added fallback to the original method if the new approach doesn't find transactions
+- Improved merchant description extraction by filtering out dates, amounts, and header information
+
+**Code Changes:**
+```typescript
+// Before: Separate extraction with index-based matching
+const descs: string[] = [];
+const descRe1 = /(?:^|\n)([A-Z0-9][A-Z0-9 @&/.'\-*,]+SINGAPORE SG)(?=\n|$)/g;
+// ... separate amount extraction ...
+
+// After: Block-based parsing ensuring merchant-amount alignment
+const transactionBlocks = text.split(/\n\s*\n/);
+for (const block of transactionBlocks) {
+  // Extract date, amount, and merchant from the same block
+  // This ensures they stay properly aligned
+}
+```
+
+**Impact:**
+- Fixes the core issue where merchant names and amounts were mismatched
+- Improves PDF parsing reliability for Standard Chartered statements
+- Maintains backward compatibility with fallback parsing
+
+## Bug 2: Incorrect Balance Calculation for Split Transactions (Logic Error)
+
+**Problem Description:**
+The balance calculation for split transactions had a fundamental flaw where it didn't properly handle cases where the split amounts didn't add up to the total transaction amount, leading to incorrect balance calculations.
+
+**Root Cause:**
+- The original logic assumed split amounts always equaled the total transaction amount
+- When splits didn't add up (due to rounding errors or manual adjustments), the balance calculation became inaccurate
+- The payer's perspective wasn't properly considered in the balance calculations
+
+**Fix Applied:**
+- Added validation to check if splits add up to the total amount
+- Implemented proportional distribution when splits don't match the total
+- Improved the balance calculation to properly track who owes what to whom
+- Added tolerance for small rounding differences (0.01)
+
+**Code Changes:**
+```typescript
+// Before: Simple balance calculation without validation
+for (const part of t.splits || []) {
+  if (part.name === payer) continue;
+  b.set(payer, (b.get(payer) || 0) + part.amount);
+  b.set(part.name, (b.get(part.name) || 0) - part.amount);
+}
+
+// After: Validated balance calculation with proportional distribution
+const totalSplit = (t.splits || []).reduce((sum, part) => sum + part.amount, 0);
+if (Math.abs(totalSplit - totalAmount) > 0.01) {
+  // Handle mismatched splits proportionally
+  const ratio = totalAmount / totalSplit;
+  // Apply ratio to each split amount
+} else {
+  // Normal case: splits add up to total
+}
+```
+
+**Impact:**
+- Fixes incorrect balance calculations for split transactions
+- Handles edge cases where split amounts don't perfectly match totals
+- Improves accuracy of friend-to-friend balance tracking
+
+## Bug 3: Memory Leak in Toast Timer (Performance/Security Issue)
+
+**Problem Description:**
+The toast timer system had a memory leak where timers were not properly cleaned up when the component unmounted, potentially causing memory leaks and security issues.
+
+**Root Cause:**
+- `toastTimer.current` was set but never cleared on component unmount
+- The `window.setTimeout` call had a TypeScript ignore comment indicating a type mismatch
+- No cleanup mechanism existed for the timer reference
+
+**Fix Applied:**
+- Changed timer type from `number` to `ReturnType<typeof setTimeout>` for proper typing
+- Replaced `window.setTimeout` with `setTimeout` for cleaner code
+- Added `useEffect` cleanup hook to clear timer on component unmount
+- Removed TypeScript ignore comments
+
+**Code Changes:**
+```typescript
+// Before: Potential memory leak with improper typing
+const toastTimer = useRef<number | null>(null);
+// @ts-ignore
+toastTimer.current = window.setTimeout(() => setToast(null), 6000);
+
+// After: Proper cleanup with correct typing
+const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+toastTimer.current = setTimeout(() => setToast(null), 6000);
+
+// Added cleanup effect
+useEffect(() => {
+  return () => {
+    if (toastTimer.current) {
+      clearTimeout(toastTimer.current);
+    }
+  };
+}, []);
+```
+
+**Impact:**
+- Prevents memory leaks from uncleaned timers
+- Improves application performance and stability
+- Fixes TypeScript type safety issues
+- Ensures proper cleanup on component unmount
+
+## Testing and Validation
+
+All fixes have been tested and validated:
+- ✅ TypeScript compilation passes without errors
+- ✅ Application builds successfully
+- ✅ No new linting errors introduced
+- ✅ Maintains backward compatibility
+
+## Recommendations
+
+1. **PDF Parsing**: Consider adding more robust error handling and logging for PDF parsing failures
+2. **Split Transactions**: Add validation UI to warn users when split amounts don't add up
+3. **Memory Management**: Consider implementing a custom hook for toast management with built-in cleanup
+4. **Testing**: Add unit tests for the PDF parsing logic to catch regressions
+
+## Files Modified
+
+- `src/BillBuddyPrototype.tsx` - All three bug fixes implemented
+- `BUG_FIXES.md` - This documentation file
+
+The application should now correctly parse PDF statements with proper merchant-amount alignment, calculate split transaction balances accurately, and manage memory properly without leaks.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes PDF parser merchant-amount mismatch, corrects split transaction balance calculation, and resolves a toast timer memory leak to improve data accuracy and application stability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
1.  **PDF Parser Merchant-Amount Mismatch**: The original `parseSCStatement` function extracted merchant descriptions and amounts separately, leading to misalignment. The fix now processes date, merchant, and amount within the same transaction block for accurate pairing.
2.  **Incorrect Balance Calculation**: The `balances` `useMemo` did not correctly handle cases where split amounts didn't perfectly sum to the total transaction amount. The updated logic now includes validation and proportional distribution to ensure accurate friend-to-friend balances.
3.  **Memory Leak in Toast Timer**: The `toastTimer` was not cleared when the component unmounted, causing a memory leak. A `useEffect` cleanup hook has been added, and the timer's type definition was corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-95a48f9c-a031-4499-8611-58d68f887217">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95a48f9c-a031-4499-8611-58d68f887217">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

