### PR TITLE
Fix duplicate lines declaration in BillBuddyPrototype

### DIFF
--- a/src/BillBuddyPrototype.tsx
+++ b/src/BillBuddyPrototype.tsx
@@ -226,13 +226,13 @@ function parseSCStatement(text: string): Txn[] {
 
 // Fallback generic
 function parseLinesToTxns(text: string): Txn[] {
-  const lines = text.split(/\n+/); const out: Txn[] = [];
+  const textLines = text.split(/\n+/); const out: Txn[] = [];
   const patterns: RegExp[] = [
     /(?<date>\d{1,2}[\/\-.]\d{1,2}[\/\-.]\d{2,4})\s+(?<desc>.+?)\s+(?<amount>-?\d{1,3}(?:,\d{3})*\.\d{2})(?:\s*(?<cr>CR))?$/,
     /(?<date>\d{1,2}\s+[A-Za-z]{3,}\s+\d{4})\s+(?<desc>.+?)\s+(?:[A-Z]{3}\s*)?(?<amount>-?\d{1,3}(?:,\d{3})*\.\d{2})(?:\s*(?<cr>CR))?$/,
     /(?<date>\d{4}-\d{2}-\d{2})\s+(?<desc>.+?)\s+(?<amount>-?\d{1,3}(?:,\d{3})*\.\d{2})(?:\s*(?<cr>CR))?$/,
   ];
-  for (const raw of lines) {
+  for (const raw of textLines) {
     let m: RegExpMatchArray | null = null;
     for (const re of patterns) { m = raw.match(re); if (m && (m as any).groups) break; }
     if (!m || !(m as any).groups) continue;


### PR DESCRIPTION
Rename `lines` variable to `textLines` in `parseLinesToTxns` to resolve a duplicate declaration error.

The error occurred because both `parseSCStatement` and `parseLinesToTxns` functions, defined in the same scope, declared a variable named `lines`, leading to a naming conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d1a0100-c730-40b7-bba9-7afb951a370b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d1a0100-c730-40b7-bba9-7afb951a370b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

